### PR TITLE
Add @devec_transform for devectorizing operations with associative types

### DIFF
--- a/src/DeExpr.jl
+++ b/src/DeExpr.jl
@@ -41,7 +41,8 @@ export
 	@devec,
 	@inspect_devec,
 	@fast_reduc,
-	@inspect_fast_reduc
+	@inspect_fast_reduc,
+	@devec_transform
 
 	
 include("fun_traits.jl")

--- a/src/scalar_backend.jl
+++ b/src/scalar_backend.jl
@@ -670,4 +670,101 @@ macro inspect_fast_reduc(info_ex, assign_ex)
 end
 
 
+##########################################################################
+#
+# 	@devec_transform - a code-generating macro for associative types 
+#
+##########################################################################
+#
+#   Starting with an associative type `d`, the following assigns or
+#   replaces key `a` with the result of `x + y` where `x` or `y` could
+#   be keys in `d`.
+#
+#       @devec_transform d  a = x + y
+#
+#   This basically converts to the following:
+#
+#       var1 = has(d, :x) ? d[:x] : x
+#       var2 = has(d, :y) ? d[:y] : y
+#       @devec res = var1 + var2
+#       d[:a] = res
+#
+#   It contains machinery to convert the symbol to a key type
+#   appropriate for the associative type. For example, DataFrames have
+#   string keys, so the symbol from the expression needs to be
+#   converted to a string. Also of issue is 
+#
+#   The following forms are supported:
+#
+#       @devec_transform d  a = x + y  b = x + sum(y)
+#
+#       @devec_transform(d, a => x + y, b => x + sum(y))
+#
+# 
+##########################################################################
 
+
+# The following is like Base.has, but converts symbols to appropriate
+# key types.
+xhas(d, key) = has(d, key)
+xhas{K<:String,V}(d::Associative{K,V}, key) = has(d, string(key))
+
+# The appropriate key for the type 
+bestkey(d, key) = key
+bestkey{K<:String,V}(d::Associative{K,V}, key) = string(key)
+
+#### The following will be needed in package DataFrames for support
+## xhas(d::AbstractDataFrame, key::Symbol) = has(d, string(key))
+## bestkey(d::AbstractDataFrame, key) = string(key)
+## bestkey(d::NamedArray, key) = string(key)
+
+# This replaces symbols with gensym'd versions and updates
+# a lookup dictionary.
+replace_syms(x, lookup::Associative) = x
+function replace_syms(s::Symbol, lookup::Associative)
+    if has(lookup, s)
+        lookup[s]
+    else
+        res = gensym("var")
+        lookup[s] = res
+        res
+    end
+end
+function replace_syms(e::Expr, lookup::Associative)
+    if e.head == :(=>)
+        e.head = :(=)
+    end
+    if e.head == :call
+        Expr(e.head, length(e.args) <= 1 ? e.args : [e.args[1], map(x -> replace_syms(x, lookup), e.args[2:end])], e.typ)
+    else
+        Expr(e.head, isempty(e.args) ? e.args : map(x -> replace_syms(x, lookup), e.args), e.typ)
+    end
+end
+
+quot(value) = expr(:quote, value)  # Toivo special
+
+function devec_transform_helper(d, args...)
+    var_lookup = Dict()
+    lhs_lookup = Dict()
+    body = Any[]
+    for ex in args
+        push!(body, compile(ScalarContext(), replace_syms(ex, var_lookup)))
+        lhs_lookup[ex.args[1]] = true
+    end
+    # header
+    header = Any[]
+    for (s,v) in var_lookup
+        push!(header, :($v = DeExpr.xhas(d, DeExpr.bestkey(d, $(quot(s)))) ? d[DeExpr.bestkey(d, $(quot(s)))] : isdefined($(DeExpr.quot(s))) ? $s : nothing))
+    end
+    # trailer
+    trailer = Any[]
+    for (s,v) in lhs_lookup
+        push!(trailer, :(d[DeExpr.bestkey(d, $(DeExpr.quot(s)))] = $(var_lookup[s])))
+    end
+    push!(trailer, :(d))
+    esc(Expr(:block, [header, body, trailer], Any))
+end
+
+macro devec_transform(df, args...)
+    devec_transform_helper(df, args...)
+end

--- a/test/test_scalar_backend.jl
+++ b/test/test_scalar_backend.jl
@@ -2,6 +2,7 @@
 
 import DeExpr
 import DeExpr.@devec
+import DeExpr.@devec_transform
 import DeExpr.@inspect_devec
 import DeExpr.@fast_reduc
 import DeExpr.@inspect_fast_reduc
@@ -386,3 +387,26 @@ end
 @test isequal(s, sum(a))
 
 
+#################################################
+#
+#	devec_transform
+#
+#################################################
+
+
+n = 4
+d = {:x => rand(n),
+     :y => pi * [1:n],
+     :z => 1 / [1:n]}
+     
+@devec_transform d  xd = x .* y + z
+
+
+
+@test isequal(d[:xd], d[:x] .* d[:y] + d[:z])
+
+@devec_transform(d,
+                 xd => x .* y + z,
+                 yd => x .* x)
+
+@test isequal(d[:yd], d[:x] .* d[:x])


### PR DESCRIPTION
I wrote this mainly to work with DataFrames (https://github.com/HarlanH/DataFrames.jl/issues/179), but since it is designed to work with all associative types, maybe you would like to include it with DeExpr. Here is an example:

``` julia
julia> d = {:x => rand(2), :y => rand(2), :z => rand(2)}
{:x=>[0.938044, 0.638445],:y=>[0.899549, 0.122162],:z=>[0.339539, 0.136685]}

julia> @devec_transform d  z2 = sqr(z)
{:z2=>[0.115287, 0.0186828],:x=>[0.938044, 0.638445],:y=>[0.899549, 0.122162],:z=>[0.339539, 0.136685]}

julia> @devec_transform(d, xyz => x + y + z)
{:z2=>[0.115287, 0.0186828],:x=>[0.938044, 0.638445],:y=>[0.899549, 0.122162],:z=>[0.339539, 0.136685],:xyz=>[2.17713, 0.897292]}

julia> @devec_transform(d, y => y .* 2)
{:z2=>[0.115287, 0.0186828],:x=>[0.938044, 0.638445],:y=>[1.7991, 0.244324],:z=>[0.339539, 0.136685],:xyz=>[2.17713, 0.897292]}

```
