### PR TITLE
Bug fix for @devec_transform

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -103,7 +103,7 @@ function devec_transform_helper(d, args...)
         push!(trailer, :(d[Devectorize.bestkey(d, $(Devectorize.quot(s)))] = $(var_lookup[s])))
     end
     push!(trailer, :(d))
-    esc(Expr(:block, [header, body, trailer], Any))
+    esc(:(let d = $d; $(Expr(:block, [header, body, trailer], Any)); end))
 end
 
 macro devec_transform(df, args...)


### PR DESCRIPTION
My initial version only worked for variables named d. Hopefully, that's fixed, now. In the process, I wrapped the expression in a `let`, so temporaries from `gensym` don't pollute the main namespace.
